### PR TITLE
Just a little -pending- enhacement

### DIFF
--- a/vicentereig/collection.coffee
+++ b/vicentereig/collection.coffee
@@ -16,18 +16,15 @@ class LinkedList
         @head = node
 
   delete: (value) ->
-    if @head?.value == value
-      deleted = @head
-      @head   = @head.next
-      @_size--
-      return deleted
+    @reject (node) -> node.value != value
 
+  reject: (callback) ->
     current = @head
     prev    = null
-    # reject!
-    while current?.next? and current.value != value
+    while current?.next? and callback.call @, current
       prev    = current
       current = current.next
+
     deleted = current
     prev.next = current.next
     @_size--
@@ -119,6 +116,6 @@ class List
   size: -> @storage.length
   clear: -> @storage = []
 
-exports.LinkedList       = LinkedList
-exports.DoublyLinkedList = DoublyLinkedList
-exports.List             = List
+@LinkedList       = LinkedList
+@DoublyLinkedList = DoublyLinkedList
+@List             = List

--- a/vicentereig/collection.js
+++ b/vicentereig/collection.js
@@ -39,16 +39,15 @@
       }, this));
     };
     LinkedList.prototype["delete"] = function(value) {
-      var current, deleted, prev, _ref;
-      if (((_ref = this.head) != null ? _ref.value : void 0) === value) {
-        deleted = this.head;
-        this.head = this.head.next;
-        this._size--;
-        return deleted;
-      }
+      return this.reject(function(node) {
+        return node.value !== value;
+      });
+    };
+    LinkedList.prototype.reject = function(callback) {
+      var current, deleted, prev;
       current = this.head;
       prev = null;
-      while (((current != null ? current.next : void 0) != null) && current.value !== value) {
+      while (((current != null ? current.next : void 0) != null) && callback.call(this, current)) {
         prev = current;
         current = current.next;
       }
@@ -221,7 +220,7 @@
     };
     return List;
   })();
-  exports.LinkedList = LinkedList;
-  exports.DoublyLinkedList = DoublyLinkedList;
-  exports.List = List;
+  this.LinkedList = LinkedList;
+  this.DoublyLinkedList = DoublyLinkedList;
+  this.List = List;
 }).call(this);

--- a/vicentereig/collection_test.coffee
+++ b/vicentereig/collection_test.coffee
@@ -7,6 +7,7 @@ assert = require('assert')
   assert.equal list.values()[1], "World"
   assert.equal list.size(), 2
   console.log "#{list}"
+
   list.delete "World"
   assert.equal list.find "World", null
   assert.equal list.size(), 1


### PR DESCRIPTION
Node.js exports _à la_ Coffeescript. The reject method, just like the Ruby one, was extracted from
the delete(value) method in order to decouple the deletion procedure from the condition used to infer which element is going to be removed.
